### PR TITLE
cs/cop smoothing groups

### DIFF
--- a/sources/utils/converter/level_mesh_commit.cxx
+++ b/sources/utils/converter/level_mesh_commit.cxx
@@ -114,45 +114,64 @@ void level_mesh::create_smoothing_groups()
 
 	create_edges(true);
 
-	uint32_t* next_sgroup = new uint32_t[m_instances.size()];
-	xr_uninitialized_fill_n(next_sgroup, m_instances.size(), 0);
-
-	std::vector<uint32_t> adjacents;
-	adjacents.reserve(512);
-	for (b_face_vec_it it = m_faces.begin(), end = m_faces.end(); it != end; ++it) {
-		if (it->sgroup != EMESH_NO_SG)
-			continue;
-		uint32_t tag = it->tag, sgroup = next_sgroup[tag];
-		xr_assert(m_instances[tag]->tag == tag);
-		bool new_sgroup = false;
-		for (uint32_t face_idx = uint32_t((it - m_faces.begin()) & UINT32_MAX);;) {
-			b_face& face = m_faces[face_idx];
-			for (uint_fast32_t i = 3, v0, v1 = face.v0; i != 0; v1 = v0) {
-				b_edge* edge = find_edge(v0 = face.v[--i], v1);
-				xr_assert(edge);
-				if (!edge->smooth)
-					continue;
-				if (!new_sgroup) {
-					new_sgroup = true;
-					face.sgroup = sgroup;
+	if (0) {	// soc format
+		uint32_t* next_sgroup = new uint32_t[m_instances.size()];
+		xr_uninitialized_fill_n(next_sgroup, m_instances.size(), 0);
+		std::vector<uint32_t> adjacents;
+		adjacents.reserve(512);
+		for (b_face_vec_it it = m_faces.begin(), end = m_faces.end(); it != end; ++it) {
+			if (it->sgroup != EMESH_NO_SG)
+				continue;
+			uint32_t tag = it->tag, sgroup = next_sgroup[tag];
+			xr_assert(m_instances[tag]->tag == tag);
+			bool new_sgroup = false;
+			for (uint32_t face_idx = uint32_t((it - m_faces.begin()) & UINT32_MAX);;) {
+				b_face& face = m_faces[face_idx];
+				for (uint_fast32_t i = 3, v0, v1 = face.v0; i != 0; v1 = v0) {
+					b_edge* edge = find_edge(v0 = face.v[--i], v1);
+					xr_assert(edge);
+					if (!edge->smooth)
+						continue;
+					if (!new_sgroup) {
+						new_sgroup = true;
+						face.sgroup = sgroup;
+					}
+					uint32_t adjacent_idx = (edge->face0 == face_idx) ?
+							face.link[i] : edge->face0;
+					b_face& adjacent = m_faces[adjacent_idx];
+					if (adjacent.sgroup == EMESH_NO_SG && adjacent.tag == tag) {
+						adjacents.push_back(adjacent_idx);
+						adjacent.sgroup = sgroup;
+					}
 				}
-				uint32_t adjacent_idx = (edge->face0 == face_idx) ?
-						face.link[i] : edge->face0;
-				b_face& adjacent = m_faces[adjacent_idx];
-				if (adjacent.sgroup == EMESH_NO_SG && adjacent.tag == tag) {
-					adjacents.push_back(adjacent_idx);
-					adjacent.sgroup = sgroup;
+				if (adjacents.empty())
+					break;
+				face_idx = adjacents.back();
+				adjacents.pop_back();
+			}
+			if (new_sgroup)
+				++next_sgroup[tag];
+		}
+		delete[] next_sgroup;
+
+	} else {	// cs/cop format
+		for (b_face_vec_it it = m_faces.begin(), end = m_faces.end(); it != end; ++it) {
+			uint32_t face_idx = uint32_t((it - m_faces.begin()) & UINT32_MAX);
+			b_face& face = *it;
+			uint32_t smoothing_data = 0;
+			for (uint_fast32_t i = 0; i < 3; ++i) {
+				uint32_t v0 = face.v[i];
+				uint32_t v1 = face.v[(i + 1) % 3];
+				b_edge* edge = find_edge(v0, v1);
+				xr_assert(edge);
+				if (!edge->smooth) {
+					smoothing_data |= (1 << i);
 				}
 			}
-			if (adjacents.empty())
-				break;
-			face_idx = adjacents.back();
-			adjacents.pop_back();
+			face.sgroup = smoothing_data;
 		}
-		if (new_sgroup)
-			++next_sgroup[tag];
 	}
-	delete[] next_sgroup;
+
 }
 
 void level_mesh::pre_commit()

--- a/sources/xray_re/xr_mesh_builder.cxx
+++ b/sources/xray_re/xr_mesh_builder.cxx
@@ -466,41 +466,61 @@ void xr_mesh_builder::create_smoothing_groups()
 
 	create_edges(true);
 
-	m_sgroups.assign(m_faces.size(), EMESH_NO_SG);
-	std::vector<uint32_t> adjacents;
-	adjacents.reserve(512);
-	uint32_t sgroup = 0;
-	for (uint_fast32_t idx = uint32_t(m_faces.size() & UINT32_MAX); idx != 0;) {
-		if (m_sgroups[--idx] != EMESH_NO_SG)
-			continue;
-		uint32_t tag = m_faces[idx].tag;
-		bool new_sgroup = false;
-		for (uint_fast32_t face_idx = idx;;) {
-			const b_face& face = m_faces[face_idx];
-			for (uint_fast32_t i = 3, v0, v1 = face.v0; i != 0; v1 = v0) {
-				b_edge* edge = find_edge(v0 = face.v[--i], v1);
-				xr_assert(edge);
-				if (!edge->smooth)
-					continue;
-				if (!new_sgroup) {
-					new_sgroup = true;
-					m_sgroups[face_idx] = sgroup;
+	if (0) {		// soc format
+		m_sgroups.assign(m_faces.size(), EMESH_NO_SG);
+		std::vector<uint32_t> adjacents;
+		adjacents.reserve(512);
+		uint32_t sgroup = 0;
+		for (uint_fast32_t idx = uint32_t(m_faces.size() & UINT32_MAX); idx != 0;) {
+			if (m_sgroups[--idx] != EMESH_NO_SG)
+				continue;
+			uint32_t tag = m_faces[idx].tag;
+			bool new_sgroup = false;
+			for (uint_fast32_t face_idx = idx;;) {
+				const b_face& face = m_faces[face_idx];
+				for (uint_fast32_t i = 3, v0, v1 = face.v0; i != 0; v1 = v0) {
+					b_edge* edge = find_edge(v0 = face.v[--i], v1);
+					xr_assert(edge);
+					if (!edge->smooth)
+						continue;
+					if (!new_sgroup) {
+						new_sgroup = true;
+						m_sgroups[face_idx] = sgroup;
+					}
+					uint32_t adjacent = (edge->face0 == face_idx) ?
+							face.link[i] : edge->face0;
+					if (m_sgroups[adjacent] == EMESH_NO_SG &&
+							m_faces[adjacent].tag == tag) {
+						adjacents.push_back(adjacent);
+						m_sgroups[adjacent] = sgroup;
+					}
 				}
-				uint32_t adjacent = (edge->face0 == face_idx) ?
-						face.link[i] : edge->face0;
-				if (m_sgroups[adjacent] == EMESH_NO_SG &&
-						m_faces[adjacent].tag == tag) {
-					adjacents.push_back(adjacent);
-					m_sgroups[adjacent] = sgroup;
+				if (adjacents.empty())
+					break;
+				face_idx = adjacents.back();
+				adjacents.pop_back();
+			}
+			if (new_sgroup)
+				++sgroup;
+		}
+	}
+
+	else {		// cs/cop format
+		m_sgroups.assign(m_faces.size(), EMESH_NO_SG);
+		for (uint_fast32_t face_idx = 0; face_idx < m_faces.size(); ++face_idx) {
+			const b_face& face = m_faces[face_idx];
+			uint32_t smoothing_data = 0;
+			for (uint_fast32_t i = 0; i < 3; ++i) {
+				uint32_t v0 = face.v[i];
+				uint32_t v1 = face.v[(i + 1) % 3];
+				b_edge* edge = find_edge(v0, v1);
+				xr_assert(edge);
+				if (!edge->smooth) {
+					smoothing_data |= (1 << i);
 				}
 			}
-			if (adjacents.empty())
-				break;
-			face_idx = adjacents.back();
-			adjacents.pop_back();
+			m_sgroups[face_idx] = smoothing_data;
 		}
-		if (new_sgroup)
-			++sgroup;
 	}
 }
 


### PR DESCRIPTION
Добавил поддержку ЧН/ЗП сглаживания. Но я не знаю, как добавить новые опции и как их учитывать. Нужно добавить такие опции:

`-sg soc`
-`sg cscop`

И почему-то при декомпиляции локации сглаживание всегда в ТЧ формате. Этот код работает только при конвертации ogf в object.